### PR TITLE
add APIs for programmatic use, supports extensions and customizations

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,53 @@ $ npm start
 🚀 Server ready at http://localhost:4000/graphql
 ```
 
+## Programmatic use
 
+```js
+import { eosGraphQLGateway, gql } from 'eosio-graphql'
+import { getMongoClient } from "./mongoClient";
+
+(async () => {
+
+  const {
+    startService,
+    server, // optional
+    service, // optional
+  } = eosGraphQLGateway({
+    mongoClient: await getMongoClient(),
+    host: 'localhost', // optional
+    port: 4000, // optional
+    buildSchema: ({ // optional
+      scalarSchema,
+      typeSchema,
+      querySchema,
+    }) => gql`
+      ${scalarSchema}
+      # my scalars
+      schema {
+        query: Query
+      }
+      ${typeSchema}
+      # my types
+      type Query {
+        ${querySchema}
+        # my queries
+      }
+    `,
+    buildResolvers(resolvers) {  // optional
+      return Object.assign(resolvers, { /* my resolvers */ });
+    },
+    abiDir = './my-abi-files/',  // optional
+  });
+
+  server.use(/* ... */);  // optional
+
+  service.use(/* ... */);  // optional
+
+  startService();
+
+})();
+```
 
 ## Contributors
 

--- a/index.ts
+++ b/index.ts
@@ -6,12 +6,12 @@ import { getResolvers, defaultBuildResolvers } from "./src/resolvers/index";
 
 export function eosGraphQLGateway(config: any = {}) {
   const {
-    host = 'localhost',
+    host = "localhost",
     port = 4000,
     mongoClient,
     buildSchema = defaultBuildSchema,
     buildResolvers = defaultBuildResolvers,
-    abiDir = '',
+    abiDir = "",
   } = config;
   const server = new ApolloServer({
     typeDefs: getTypeDefs({

--- a/index.ts
+++ b/index.ts
@@ -1,13 +1,43 @@
 import express from "express";
 import { ApolloServer } from "apollo-server-express";
-import { typeDefs } from "./src/typeDefs/index";
-import { resolvers } from "./src/resolvers/index";
+import { gql } from "apollo-server";
+import { getTypeDefs, defaultBuildSchema } from "./src/typeDefs/index";
+import { getResolvers, defaultBuildResolvers } from "./src/resolvers/index";
 
-const server = new ApolloServer({ typeDefs, resolvers });
+export function eosGraphQLGateway(config: any = {}) {
+  const {
+    host = 'localhost',
+    port = 4000,
+    mongoClient,
+    buildSchema = defaultBuildSchema,
+    buildResolvers = defaultBuildResolvers,
+    abiDir = '',
+  } = config;
+  const server = new ApolloServer({
+    typeDefs: getTypeDefs({
+      abiDir,
+      buildSchema,
+    }),
+    resolvers: getResolvers({
+      abiDir,
+      buildResolvers,
+      mongoClient,
+    }),
+  });
+  const app = express();
 
-const app = express();
-server.applyMiddleware({ app });
+  function startService() {
+    server.applyMiddleware({ app });
 
-app.listen({ port: 4000 }, () =>
-  console.log(`🚀 Server ready at http://localhost:4000${server.graphqlPath}`),
-);
+    app.listen({ host, port }, () =>
+      console.log(`🚀 Server ready at http://${host}:${port}${server.graphqlPath}`),
+    );
+  }
+
+  return {
+    server,
+    gql,
+    service: app,
+    startService,
+  };
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eosio-graphql",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "tslint --project .",
-    "start": "tsc && node index.js"
+    "start": "tsc && node service.js"
   },
   "repository": {
     "type": "git",

--- a/service.ts
+++ b/service.ts
@@ -1,4 +1,4 @@
-import { eosGraphQLGateway } from './'
+import { eosGraphQLGateway } from "./"
 import { getMongoClient } from "./src/utils/mongoClient";
 
 (async () => {

--- a/service.ts
+++ b/service.ts
@@ -1,0 +1,10 @@
+import { eosGraphQLGateway } from './'
+import { getMongoClient } from "./src/utils/mongoClient";
+
+(async () => {
+
+  eosGraphQLGateway({
+    mongoClient: await getMongoClient(),
+  }).startService();
+
+})();

--- a/src/abi/index.ts
+++ b/src/abi/index.ts
@@ -3,38 +3,47 @@ import * as path from "path";
 import * as glob from "glob";
 import { convertType } from "../utils";
 
-export const abis: {
-  [name: string]: {
-    [action: string]: {
-      [type: string]: "String" | "Int";
+export function getAbis({ userDir = '' }) {
+  const abis: {
+    [name: string]: {
+      [action: string]: {
+        [type: string]: "String" | "Int";
+      };
     };
-  };
-} = {};
+  } = {};
 
-// Load all abi
-glob.sync(path.join(__dirname, "*.abi")).forEach((filepath) => {
-  const abiName = path.parse(filepath).name;
-  const abi = JSON.parse(fs.readFileSync(filepath, "utf8"));
-  const actions: any = {};
-  const types: any = {};
-  const structs: any = {};
+  function loadAbi(filepath: string) {
+    const abiName = path.parse(filepath).name;
+    const abi = JSON.parse(fs.readFileSync(filepath, "utf8"));
+    const actions: any = {};
+    const types: any = {};
+    const structs: any = {};
 
-  // Types
-  for (const type of abi.types) {
-    types[type.new_type_name] = convertType(type.type);
-  }
-
-  // Structs
-  for (const struct of abi.structs) {
-    const structFields: any = {};
-    for (const field of struct.fields) {
-      structFields[field.name] = convertType(field.type);
+    // Types
+    for (const type of abi.types) {
+      types[type.new_type_name] = convertType(type.type);
     }
-    structs[struct.name] = structFields;
+
+    // Structs
+    for (const struct of abi.structs) {
+      const structFields: any = {};
+      for (const field of struct.fields) {
+        structFields[field.name] = convertType(field.type);
+      }
+      structs[struct.name] = structFields;
+    }
+
+    for (const action of abi.actions) {
+      actions[action.name] = structs[action.type];
+    }
+    abis[abiName] = actions;
   }
 
-  for (const action of abi.actions) {
-    actions[action.name] = structs[action.type];
+  // Load all abi
+  glob.sync(path.join(__dirname, "*.abi")).forEach(loadAbi);
+  if (userDir) {
+    glob.sync(path.join(userDir, "*.abi")).forEach(loadAbi);
   }
-  abis[abiName] = actions;
-});
+
+  return abis
+}

--- a/src/abi/index.ts
+++ b/src/abi/index.ts
@@ -3,7 +3,7 @@ import * as path from "path";
 import * as glob from "glob";
 import { convertType } from "../utils";
 
-export function getAbis({ userDir = '' }) {
+export function getAbis({ userDir = "" }) {
   const abis: {
     [name: string]: {
       [action: string]: {
@@ -45,5 +45,5 @@ export function getAbis({ userDir = '' }) {
     glob.sync(path.join(userDir, "*.abi")).forEach(loadAbi);
   }
 
-  return abis
+  return abis;
 }

--- a/src/resolvers/abi.ts
+++ b/src/resolvers/abi.ts
@@ -1,55 +1,62 @@
+import { MongoClient } from "mongodb";
 import { getActions } from "eosio-mongodb-queries";
-import { client } from "../utils/mongoClient";
-import { abis } from "../abi";
+import { getAbis } from "../abi";
 import { isString } from "util";
 
-export const abiResolvers: any = {};
+export function getAbiResolvers({
+  abiDir = '',
+  mongoClient,
+}: {
+  abiDir: string
+  mongoClient: MongoClient
+}) {
+  const abiResolvers: any = {};
+  const abis: any = getAbis({ userDir: abiDir })
 
-for (const account of Object.keys(abis)) {
+  for (const account of Object.keys(abis)) {
     const query = account.replace(".", "");
     const resolver: any = {};
 
     for (const name of Object.keys(abis[account])) {
-        resolver[name] = async (options: any) => {
-            if (!client) { throw new Error("MongoClient is not initialized"); }
-
-            // Optional parameters
-            if (!options.match) {
-                const match: any = {};
-                for (const key of Object.keys(options)) {
-                    switch (key) {
-                    case "block_id":
-                    case "block_num":
-                    case "irreversible":
-                    case "trx_id":
-                    case "skip":
-                    case "limit":
-                    case "sort":
-                    case "lte_block_num":
-                    case "gte_block_num":
-                    case "match":
-                        break;
-                    default:
-                        match["data." + key] = options[key];
-                    }
-                }
-                options.match = match;
+      resolver[name] = async (options: any) => {
+        // Optional parameters
+        if (!options.match) {
+          const match: any = {};
+          for (const key of Object.keys(options)) {
+            switch (key) {
+            case "block_id":
+            case "block_num":
+            case "irreversible":
+            case "trx_id":
+            case "skip":
+            case "limit":
+            case "sort":
+            case "lte_block_num":
+            case "gte_block_num":
+            case "match":
+              break;
+            default:
+              match["data." + key] = options[key];
             }
+          }
+          options.match = match;
+        }
 
-            // Set required parameters
-            options.account = account;
-            options.name = name;
+        // Set required parameters
+        options.account = account;
+        options.name = name;
 
-            // Handle Regex queries
-            if (options.match && isString(options.match)) { options.match = JSON.parse(options.match); }
+        // Handle Regex queries
+        if (options.match && isString(options.match)) { options.match = JSON.parse(options.match); }
 
-            const now = Date.now();
-            const cursor = await getActions(client, options);
-            const result = await cursor.toArray();
-            const elapsed = Date.now() - now;
-            console.log(JSON.stringify({elapsed, query: `abi.${account}.${name}`, options}));
-            return result;
-        };
+        const now = Date.now();
+        const cursor = await getActions(mongoClient, options);
+        const result = await cursor.toArray();
+        const elapsed = Date.now() - now;
+        console.log(JSON.stringify({elapsed, query: `abi.${account}.${name}`, options}));
+        return result;
+      };
     }
     abiResolvers[query] = () => resolver;
+  }
 }

--- a/src/resolvers/abi.ts
+++ b/src/resolvers/abi.ts
@@ -4,14 +4,14 @@ import { getAbis } from "../abi";
 import { isString } from "util";
 
 export function getAbiResolvers({
-  abiDir = '',
+  abiDir = "",
   mongoClient,
 }: {
-  abiDir: string
-  mongoClient: MongoClient
+  abiDir: string,
+  mongoClient: MongoClient,
 }) {
   const abiResolvers: any = {};
-  const abis: any = getAbis({ userDir: abiDir })
+  const abis: any = getAbis({ userDir: abiDir });
 
   for (const account of Object.keys(abis)) {
     const query = account.replace(".", "");

--- a/src/resolvers/index.ts
+++ b/src/resolvers/index.ts
@@ -26,13 +26,13 @@ export function defaultBuildResolvers(resolvers: any) {
 }
 
 export function getResolvers({
-  abiDir = '',
+  abiDir = "",
   buildResolvers = defaultBuildResolvers,
   mongoClient,
 }: {
-  abiDir: string
-  buildResolvers: Function
-  mongoClient: MongoClient
+  abiDir: string,
+  buildResolvers: (resolvers: any) => any,
+  mongoClient: MongoClient,
 }) {
   // Load MongoDB resolvers
   Object.assign(Query, getMongodbResolvers({ mongoClient }));
@@ -45,5 +45,5 @@ export function getResolvers({
     JSON: GraphQLJSON,
   };
 
-  return buildResolvers(resolvers)
+  return buildResolvers(resolvers);
 }

--- a/src/resolvers/mongodb/account.ts
+++ b/src/resolvers/mongodb/account.ts
@@ -1,12 +1,16 @@
-import { client } from "../../utils/mongoClient";
+import { MongoClient } from "mongodb";
 import { getAccount } from "eosio-mongodb-queries";
 
-export const account = async (_: any, options: any) => {
-    if (!client) { throw new Error("MongoClient is not initialized"); }
-
+const getAccountResolver = ({
+  mongoClient
+}: {
+  mongoClient: MongoClient
+}) => async (_: any, options: any) => {
     const now = Date.now();
-    const result = await getAccount(client, options.name, options);
+    const result = await getAccount(mongoClient, options.name, options);
     const elapsed = Date.now() - now;
     console.log(JSON.stringify({elapsed, query: "mongodb.account", options}));
     return result;
 };
+
+export default getAccountResolver;

--- a/src/resolvers/mongodb/account.ts
+++ b/src/resolvers/mongodb/account.ts
@@ -2,9 +2,9 @@ import { MongoClient } from "mongodb";
 import { getAccount } from "eosio-mongodb-queries";
 
 const getAccountResolver = ({
-  mongoClient
+  mongoClient,
 }: {
-  mongoClient: MongoClient
+  mongoClient: MongoClient,
 }) => async (_: any, options: any) => {
     const now = Date.now();
     const result = await getAccount(mongoClient, options.name, options);

--- a/src/resolvers/mongodb/actions.ts
+++ b/src/resolvers/mongodb/actions.ts
@@ -4,9 +4,9 @@ import { flattenObject } from "../../utils";
 import { isString } from "util";
 
 const getActionsResolver = ({
-  mongoClient
+  mongoClient,
 }: {
-  mongoClient: MongoClient
+  mongoClient: MongoClient,
 }) => async (_: any, options: any) => {
     // Handles simple data match
     if (options.match && options.match.data) { options.match = flattenObject(options.match); }

--- a/src/resolvers/mongodb/actions.ts
+++ b/src/resolvers/mongodb/actions.ts
@@ -1,19 +1,24 @@
-import { client } from "../../utils/mongoClient";
-import { flattenObject } from "../../utils";
+import { MongoClient } from "mongodb";
 import { getActions } from "eosio-mongodb-queries";
+import { flattenObject } from "../../utils";
 import { isString } from "util";
 
-export const actions = async (_: any, options: any) => {
-    if (!client) { throw new Error("MongoClient is not initialized"); }
+const getActionsResolver = ({
+  mongoClient
+}: {
+  mongoClient: MongoClient
+}) => async (_: any, options: any) => {
     // Handles simple data match
     if (options.match && options.match.data) { options.match = flattenObject(options.match); }
     // Handle Regex queries
     if (options.match && isString(options.match)) { options.match = JSON.parse(options.match); }
 
     const now = Date.now();
-    const cursor = await getActions(client, options);
+    const cursor = await getActions(mongoClient, options);
     const result = await cursor.toArray();
     const elapsed = Date.now() - now;
     console.log(JSON.stringify({elapsed, query: "mongodb.actions", options}));
     return result;
 };
+
+export default getActionsResolver;

--- a/src/resolvers/mongodb/blocks.ts
+++ b/src/resolvers/mongodb/blocks.ts
@@ -4,9 +4,9 @@ import { flattenObject } from "../../utils";
 import { isString } from "util";
 
 const getBlocksResolver = ({
-  mongoClient
+  mongoClient,
 }: {
-  mongoClient: MongoClient
+  mongoClient: MongoClient,
 }) => async (_: any, options: any) => {
     // Handles simple block match
     if (options.match && options.match.block) { options.match = flattenObject(options.match); }

--- a/src/resolvers/mongodb/blocks.ts
+++ b/src/resolvers/mongodb/blocks.ts
@@ -1,19 +1,24 @@
-import { client } from "../../utils/mongoClient";
-import { flattenObject } from "../../utils";
+import { MongoClient } from "mongodb";
 import { getBlocks } from "eosio-mongodb-queries";
+import { flattenObject } from "../../utils";
 import { isString } from "util";
 
-export const blocks = async (_: any, options: any) => {
-    if (!client) { throw new Error("MongoClient is not initialized"); }
+const getBlocksResolver = ({
+  mongoClient
+}: {
+  mongoClient: MongoClient
+}) => async (_: any, options: any) => {
     // Handles simple block match
     if (options.match && options.match.block) { options.match = flattenObject(options.match); }
     // Handle Regex queries
     if (options.match && isString(options.match)) { options.match = JSON.parse(options.match); }
 
     const now = Date.now();
-    const cursor = await getBlocks(client, options);
+    const cursor = await getBlocks(mongoClient, options);
     const result = await cursor.toArray();
     const elapsed = Date.now() - now;
     console.log(JSON.stringify({elapsed, query: "mongodb.blocks", options}));
     return result;
 };
+
+export default getBlocksResolver;

--- a/src/resolvers/mongodb/count.ts
+++ b/src/resolvers/mongodb/count.ts
@@ -1,17 +1,20 @@
-import { client } from "../../utils/mongoClient";
-// import { flattenObject } from "../../utils";
+import { MongoClient } from "mongodb";
 import * as queries from "eosio-mongodb-queries";
+// import { flattenObject } from "../../utils";
 // import { isString } from "util";
 
-export const count = async (_: any, options: any) => {
-    if (!client) { throw new Error("MongoClient is not initialized"); }
+const getCountResolver = ({
+  mongoClient
+}: {
+  mongoClient: MongoClient
+}) => async (_: any, options: any) => {
     const now = Date.now();
-    const account_controls = await queries.count(client, "account_controls");
-    const accounts = await queries.count(client, "accounts");
-    const actions = await queries.count(client, "actions");
-    const blocks = await queries.count(client, "blocks");
-    const pub_keys = await queries.count(client, "pub_keys");
-    const transactions = await queries.count(client, "transactions");
+    const account_controls = await queries.count(mongoClient, "account_controls");
+    const accounts = await queries.count(mongoClient, "accounts");
+    const actions = await queries.count(mongoClient, "actions");
+    const blocks = await queries.count(mongoClient, "blocks");
+    const pub_keys = await queries.count(mongoClient, "pub_keys");
+    const transactions = await queries.count(mongoClient, "transactions");
 
     const elapsed = Date.now() - now;
     console.log(JSON.stringify({elapsed, query: "mongodb.count", options}));
@@ -24,3 +27,5 @@ export const count = async (_: any, options: any) => {
         transactions,
     };
 };
+
+export default getCountResolver;

--- a/src/resolvers/mongodb/count.ts
+++ b/src/resolvers/mongodb/count.ts
@@ -4,9 +4,9 @@ import * as queries from "eosio-mongodb-queries";
 // import { isString } from "util";
 
 const getCountResolver = ({
-  mongoClient
+  mongoClient,
 }: {
-  mongoClient: MongoClient
+  mongoClient: MongoClient,
 }) => async (_: any, options: any) => {
     const now = Date.now();
     const account_controls = await queries.count(mongoClient, "account_controls");

--- a/src/resolvers/mongodb/index.ts
+++ b/src/resolvers/mongodb/index.ts
@@ -7,7 +7,7 @@ import getCountResolver from "./count";
 export function getMongodbResolvers({
   mongoClient,
 }: {
-  mongoClient: MongoClient
+  mongoClient: MongoClient,
 }) {
   if (!mongoClient) { throw new Error("MongoClient is not initialized"); }
   return {
@@ -15,5 +15,5 @@ export function getMongodbResolvers({
     actions: getActionsResolver({ mongoClient }),
     blocks: getBlocksResolver({ mongoClient }),
     count: getCountResolver({ mongoClient }),
-  }
+  };
 }

--- a/src/resolvers/mongodb/index.ts
+++ b/src/resolvers/mongodb/index.ts
@@ -1,4 +1,19 @@
-export * from "./account";
-export * from "./actions";
-export * from "./blocks";
-export * from "./count";
+import { MongoClient } from "mongodb";
+import getAccountResolver from "./account";
+import getActionsResolver from "./actions";
+import getBlocksResolver from "./blocks";
+import getCountResolver from "./count";
+
+export function getMongodbResolvers({
+  mongoClient,
+}: {
+  mongoClient: MongoClient
+}) {
+  if (!mongoClient) { throw new Error("MongoClient is not initialized"); }
+  return {
+    account: getAccountResolver({ mongoClient }),
+    actions: getActionsResolver({ mongoClient }),
+    blocks: getBlocksResolver({ mongoClient }),
+    count: getCountResolver({ mongoClient }),
+  }
+}

--- a/src/typeDefs/abi.ts
+++ b/src/typeDefs/abi.ts
@@ -1,14 +1,16 @@
 import { templateParamsAction, templateTypesAction } from "./templates";
 import { toTitleCase } from "../utils";
-import { abis } from "../abi";
+import { getAbis } from "../abi";
 
-// Dynamically load ABI's
-export let abiTypeDefs = "";
-export let abiTypeDefsData = "";
-export let abiQueries = "";
-export let abiActions = "";
+export function getAbiSchema({ abiDir = '' }) {
+  // Dynamically load ABI's
+  let abiTypeDefs = "";
+  let abiTypeDefsData = "";
+  let abiQueries = "";
+  let abiActions = "";
+  const abis: any = getAbis({ userDir: abiDir })
 
-for (const name of Object.keys(abis)) {
+  for (const name of Object.keys(abis)) {
     // Name of Smart Contract
     const nameType = name.split(".").map((n) => toTitleCase(n)).join("");
     const nameQuery = name.replace(".", "");
@@ -16,43 +18,50 @@ for (const name of Object.keys(abis)) {
     abiActions += `\ntype ${nameType} {`;
 
     for (const action of Object.keys(abis[name])) {
-        // Smart Contract + Action Name
-        abiActions += `\n     ${action}(`;
+      // Smart Contract + Action Name
+      abiActions += `\n     ${action}(`;
 
-        for (const field of Object.keys(abis[name][action])) {
-          // Field Name + Data Type
-          const type = abis[name][action][field];
-          abiActions += `\n        ${field}: ${type},`;
-        }
-        abiActions += templateParamsAction;
-        abiActions += `    ): [${nameType}${toTitleCase(action)}]\n`;
+      for (const field of Object.keys(abis[name][action])) {
+        // Field Name + Data Type
+        const type = abis[name][action][field];
+        abiActions += `\n        ${field}: ${type},`;
+      }
+      abiActions += templateParamsAction;
+      abiActions += `    ): [${nameType}${toTitleCase(action)}]\n`;
     }
     abiActions += "}\n";
-}
+  }
 
-// abiTypeDefsData
-for (const name of Object.keys(abis)) {
+  // abiTypeDefsData
+  for (const name of Object.keys(abis)) {
     const nameType = name.split(".").map((n) => toTitleCase(n)).join("");
     // Actions
     for (const action of Object.keys(abis[name])) {
-        abiTypeDefsData += `\ntype ${nameType}${toTitleCase(action)}Data {`;
-        // Fields
-        for (const field of Object.keys(abis[name][action])) {
-          const type = abis[name][action][field];
-          abiTypeDefsData += `\n    ${field}: ${type},`;
-        }
-        abiTypeDefsData += "\n}\n";
+      abiTypeDefsData += `\ntype ${nameType}${toTitleCase(action)}Data {`;
+      // Fields
+      for (const field of Object.keys(abis[name][action])) {
+        const type = abis[name][action][field];
+        abiTypeDefsData += `\n    ${field}: ${type},`;
+      }
+      abiTypeDefsData += "\n}\n";
     }
-}
+  }
 
-// abiTypeDefs
-for (const name of Object.keys(abis)) {
+  // abiTypeDefs
+  for (const name of Object.keys(abis)) {
     const nameType = name.split(".").map((n) => toTitleCase(n)).join("");
     // Actions
     for (const action of Object.keys(abis[name])) {
-        abiTypeDefs += `\ntype ${nameType}${toTitleCase(action)} {`;
-        abiTypeDefs += templateTypesAction;
-        abiTypeDefs += `    data: ${nameType}${toTitleCase(action)}Data`;
-        abiTypeDefs += "\n}\n";
+      abiTypeDefs += `\ntype ${nameType}${toTitleCase(action)} {`;
+      abiTypeDefs += templateTypesAction;
+      abiTypeDefs += `    data: ${nameType}${toTitleCase(action)}Data`;
+      abiTypeDefs += "\n}\n";
     }
+  }
+  return {
+    abiTypeDefs,
+    abiTypeDefsData,
+    abiQueries,
+    abiActions,
+  }
 }

--- a/src/typeDefs/abi.ts
+++ b/src/typeDefs/abi.ts
@@ -2,13 +2,13 @@ import { templateParamsAction, templateTypesAction } from "./templates";
 import { toTitleCase } from "../utils";
 import { getAbis } from "../abi";
 
-export function getAbiSchema({ abiDir = '' }) {
+export function getAbiSchema({ abiDir = "" }) {
   // Dynamically load ABI's
   let abiTypeDefs = "";
   let abiTypeDefsData = "";
   let abiQueries = "";
   let abiActions = "";
-  const abis: any = getAbis({ userDir: abiDir })
+  const abis: any = getAbis({ userDir: abiDir });
 
   for (const name of Object.keys(abis)) {
     // Name of Smart Contract
@@ -63,5 +63,5 @@ export function getAbiSchema({ abiDir = '' }) {
     abiTypeDefsData,
     abiQueries,
     abiActions,
-  }
+  };
 }

--- a/src/typeDefs/index.ts
+++ b/src/typeDefs/index.ts
@@ -1,30 +1,59 @@
 import { gql } from "apollo-server";
 import { authorization } from "./templates";
 import { mongodb } from "./mongodb";
-import { abiActions, abiQueries, abiTypeDefs, abiTypeDefsData } from "./abi";
+import { getAbiSchema } from "./abi";
 
-// The GraphQL schema in string form
-export const typeDefs = gql`
-    scalar JSON
+export function defaultBuildSchema({
+  scalarSchema = '',
+  typeSchema = '',
+  querySchema = '',
+}) {
+  // The GraphQL schema in string form
+  return gql`
+      ${scalarSchema}
 
-    schema {
-        query: Query
-    }
+      schema {
+          query: Query
+      }
 
-    ${authorization}
-    ${mongodb}
+      ${typeSchema}
 
-    ${abiActions}
-    ${abiTypeDefs}
-    ${abiTypeDefsData}
+      type Query {
+          ${querySchema}
+      }
+  `;
+}
 
-    type Query {
-        name: String
-        version: JSON
-        license: String
-        author: String
-        homepage: String
-        contributors: [String]
-        ${abiQueries}
-    }
-`;
+export function getTypeDefs({
+  abiDir = '',
+  buildSchema = defaultBuildSchema,
+}) {
+  const {
+    abiActions,
+    abiQueries,
+    abiTypeDefs,
+    abiTypeDefsData,
+  } = getAbiSchema({ abiDir })
+  return buildSchema({
+    scalarSchema: `
+      scalar JSON
+    `,
+    typeSchema: `
+      ${authorization}
+      ${mongodb}
+
+      ${abiActions}
+      ${abiTypeDefs}
+      ${abiTypeDefsData}
+    `,
+    querySchema: `
+      name: String
+      version: JSON
+      license: String
+      author: String
+      homepage: String
+      contributors: [String]
+      ${abiQueries}
+    `
+  })
+};

--- a/src/typeDefs/index.ts
+++ b/src/typeDefs/index.ts
@@ -4,9 +4,9 @@ import { mongodb } from "./mongodb";
 import { getAbiSchema } from "./abi";
 
 export function defaultBuildSchema({
-  scalarSchema = '',
-  typeSchema = '',
-  querySchema = '',
+  scalarSchema = "",
+  typeSchema = "",
+  querySchema = "",
 }) {
   // The GraphQL schema in string form
   return gql`
@@ -25,7 +25,7 @@ export function defaultBuildSchema({
 }
 
 export function getTypeDefs({
-  abiDir = '',
+  abiDir = "",
   buildSchema = defaultBuildSchema,
 }) {
   const {
@@ -33,7 +33,7 @@ export function getTypeDefs({
     abiQueries,
     abiTypeDefs,
     abiTypeDefsData,
-  } = getAbiSchema({ abiDir })
+  } = getAbiSchema({ abiDir });
   return buildSchema({
     scalarSchema: `
       scalar JSON
@@ -54,6 +54,6 @@ export function getTypeDefs({
       homepage: String
       contributors: [String]
       ${abiQueries}
-    `
-  })
-};
+    `,
+  });
+}

--- a/src/utils/mongoClient.ts
+++ b/src/utils/mongoClient.ts
@@ -3,9 +3,8 @@ import { MONGODB_URI } from "../../config";
 
 export let client: MongoClient | null = null;
 
-// Intialize MongoDB Client
-(async () => {
-    if (!client) {
-        client = await MongoClient.connect(MONGODB_URI, { useNewUrlParser: true });
-    }
-})();
+export async function getMongoClient() {
+  // Intialize MongoDB Client
+  const client: MongoClient = await MongoClient.connect(MONGODB_URI, { useNewUrlParser: true });
+  return client
+}


### PR DESCRIPTION
Hi, I'm from EOS Asia. We love this project and are using it to build an API gateway service for our app. 

Forking this project and adding our specific business requirements to it is obviously a sub-optimal solution. This PR adds programmatic APIs to `eosio-graphql` so it can be used as a library and supports extensions and customizations.

Usage:

```js
import { eosGraphQLGateway, gql } from 'eosio-graphql'
import { getMongoClient } from "./mongoClient";

(async () => {

  const {
    startService,
    server, // optional
    service, // optional
  } = eosGraphQLGateway({
    mongoClient: await getMongoClient(),
    host: 'localhost', // optional
    port: 4000, // optional
    buildSchema: ({ // optional
      scalarSchema,
      typeSchema,
      querySchema,
    }) => gql`
      ${scalarSchema}
      # my scalars
      schema {
        query: Query
      }
      ${typeSchema}
      # my types
      type Query {
        ${querySchema}
        # my queries
      }
    `,
    buildResolvers(resolvers) {  // optional
      return Object.assign(resolvers, { /* my resolvers */ });
    },
    abiDir = './my-abi-files/',  // optional
  });

  server.use(/* ... */);  // optional

  service.use(/* ... */);  // optional

  startService();

})();
```